### PR TITLE
Add option `exportsOnly`

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -83,7 +83,7 @@ export default declare((api, options) => {
 
                 // Look for `require()` any renaming is assumed to be intentionally
                 // done to break state kind of check, so we won't look for aliases.
-                if (t.isIdentifier(node.callee) && node.callee.name === 'require') {
+                if (!options.exportsOnly && t.isIdentifier(node.callee) && node.callee.name === 'require') {
                   // Require must be global for us to consider this a CommonJS
                   // module.
                   state.isCJS = true;


### PR DESCRIPTION
I'm working on a project that bundles CommonJS modules into ES modules with all their dependencies included. To do this I only need the exports to be converted to the ESM format, while the require calls need to stay in place to be passed on to browserify. I managed to achieve this behaviour using this transform, by adding a simple `exportsOnly` option. It would help me a lot if this could be merged in!

Do let me know if you have any remarks or requests.