### PR TITLE
WIP: fix: replace `this` exports with `exports` identifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.vscode


### PR DESCRIPTION
Replaced top level `this` exports with simpler logic. It now renames the top level `this` keywords to `exports`.

IIFE is now only used for `ReturnStatement`.

Fixes: https://github.com/tbranyen/babel-plugin-transform-commonjs/issues/15