### PR TITLE
fix: ignore computed export properties

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -343,9 +343,14 @@ export default declare((api, options) => {
             }
             // Check for regular exports
             else if (path.node.left.object.name === 'exports') {
-              const { name } = path.node.left.property;
+              const { property, computed } = path.node.left;
+              const { name } = property;
+
               if (
                 exportsBinding
+                // Ignore computed properties
+                // e.g. `let e = 'name'; exports[e] = 'export'`
+                || computed
                 // If export is named "default" leave as is.
                 // It is not possible to export "default" as a named export.
                 // e.g. `export.default = 'a'`

--- a/test/index.js
+++ b/test/index.js
@@ -302,6 +302,25 @@ describe('Transform CommonJS', function() {
         export default module.exports;
       `);
     });
+
+    it('can ignore computed export properties', async () => {
+      const input = `
+        const e = 'name';
+        exports[e] = 'export'
+      `;
+
+      const { code } = await transformAsync(input, { ...defaults });
+
+      equal(code, format`
+        var module = {
+          exports: {}
+        };
+        var exports = module.exports;
+        const e = 'name';
+        exports[e] = 'export';
+        export default module.exports;
+      `);
+    });
   });
 
   describe('Require', () => {


### PR DESCRIPTION
Ignore computed export properties. The name is auto generated from the variable name so it isn't relational to the actual `exports` name.

It could be possible to read the variable, and if it's a valid string use that as the named export name. Although looking through the AST, the `Identifier` name doesn't seem to be available 🤔

Issue: https://babeljs.io/repl#?babili=false&browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=EQVwzgpgBGAuBOBLAxrYBuAUJ5B7AdnFPgIYC20AvFAOQAmJAbonTZhAB4AOu8sYAbVIUAulGoBvTFAAWERAHMZsAFxQAbACYANFEwBfTEA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=&prettier=false&targets=&version=7.6.2&externalPlugins=babel-plugin-transform-commonjs%401.1.6