### PR TITLE
Invalid exports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: node_js
 node_js:
-  - "10.10"
+  - "14.4.0"
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,6 @@
 import { declare } from '@babel/helper-plugin-utils';
 import { types as t } from '@babel/core';
+import { check } from 'reserved-words';
 
 export default declare((api, options) => {
   api.assertVersion(7);
@@ -385,6 +386,11 @@ export default declare((api, options) => {
                 const newName = path.scope.generateUidIdentifier(name).name;
 
                 path.scope.rename(name, newName);
+
+                // Check if this name is reserved, if so, then bail out.
+                if (check(name)) {
+                  return;
+                }
 
                 const decl = t.exportNamedDeclaration(
                   t.variableDeclaration('let', [

--- a/package.json
+++ b/package.json
@@ -31,11 +31,13 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": ">=7"
+    "@babel/core": ">=7",
+    "reserved-words": "^0.1.2"
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",
     "@types/babel__core": "^7.1.3",
+    "@types/reserved-words": "^0.1.0",
     "mocha": "^5.2.0",
     "ts-node": "7.0.1",
     "typescript": "^3.1.1"

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   },
   "homepage": "https://github.com/tbranyen/babel-plugin-transform-commonjs#readme",
   "dependencies": {
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.0.0",
+    "reserved-words": "^0.1.2"
   },
   "peerDependencies": {
-    "@babel/core": ">=7",
-    "reserved-words": "^0.1.2"
+    "@babel/core": ">=7"
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",

--- a/test/index.js
+++ b/test/index.js
@@ -630,6 +630,26 @@ describe('Transform CommonJS', function() {
       `);
     });
 
+    it.only('can support a reserved word identifier', async () => {
+      const input = `
+        exports.super = () => {};
+      `;
+
+      const { code } = await transformAsync(input, { ...defaults });
+
+      equal(code, format`
+        var module = {
+          exports: {}
+        };
+        var exports = module.exports;
+
+        exports.super = () => {};
+
+        export default module.exports;
+      `);
+
+    });
+
     it('can support nested default', async () => {
       const input = `
         if (true) {

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-const { throws, equal, deepEqual } = require('assert');
+const { equal, deepEqual, match } = require('assert');
 const { transformAsync } = require('@babel/core');
 const { default: traverseAst } = require('@babel/traverse');
 const { format } = require('./_utils');
@@ -485,7 +485,7 @@ describe('Transform CommonJS', function() {
       `;
 
       await transformAsync(input, { ...defaults }).catch(ex => {
-        equal(ex.toString(), `Error: Invalid require signature: require(name)`);
+        match(ex.toString(), /Invalid require signature: require\(name\)/);
       });
     });
 
@@ -531,7 +531,7 @@ describe('Transform CommonJS', function() {
       `;
 
       await transformAsync(input, { ...defaults }).catch(ex => {
-        equal(ex.toString(), `Error: Invalid require signature: require('pat' + 'h')`);
+        match(ex.toString(), /Invalid require signature: require\('pat' \+ 'h'\)/);
       });
     });
 
@@ -630,7 +630,7 @@ describe('Transform CommonJS', function() {
       `);
     });
 
-    it.only('can support a reserved word identifier', async () => {
+    it('can support a reserved word identifier', async () => {
       const input = `
         exports.super = () => {};
       `;


### PR DESCRIPTION
This enables the exporting of reserved words via default export. Previously this module would attempt to register them as named exports.